### PR TITLE
Use current timezone for ZipArchiveEntry

### DIFF
--- a/lib/archivers/zip/util.js
+++ b/lib/archivers/zip/util.js
@@ -19,11 +19,11 @@ util.dateToDos = function(d) {
 
   var val = {
     year: year,
-    month: d.getUTCMonth(),
-    date: d.getUTCDate(),
-    hours: d.getUTCHours(),
-    minutes: d.getUTCMinutes(),
-    seconds: d.getUTCSeconds()
+    month: d.getMonth(),
+    date: d.getDate(),
+    hours: d.getHours(),
+    minutes: d.getMinutes(),
+    seconds: d.getSeconds()
   };
 
   return ((val.year - 1980) << 25) | ((val.month + 1) << 21) | (val.date << 16) |


### PR DESCRIPTION
Hi !

I stumbled upon an issue I might have a solution for, so here's a pull request!

Grabbing the UTC time into the ZipArchiveEntry object (and converting it through the util.dateToDos method) seems to break the timezones offsets, resulting in the zip entries being outdated by [your-time-zone-offset] in comparison with the original file.

Hope it helps !
