### PR TITLE
Source stream error

### DIFF
--- a/lib/archivers/archive-output-stream.js
+++ b/lib/archivers/archive-output-stream.js
@@ -85,7 +85,6 @@ ArchiveOutputStream.prototype.entry = function(ae, source, callback) {
   if (Buffer.isBuffer(source)) {
     this._appendBuffer(ae, source, callback);
   } else if (util.isStream(source)) {
-    source.on('error', callback);
     this._appendStream(ae, source, callback);
   } else {
     this._archive.processing = false;

--- a/lib/archivers/zip/zip-archive-output-stream.js
+++ b/lib/archivers/zip/zip-archive-output-stream.js
@@ -92,7 +92,8 @@ ZipArchiveOutputStream.prototype._appendStream = function(ae, source, callback) 
   this._writeLocalFileHeader(ae);
 
   var smart = this._smartStream(ae, callback);
-  source.once('error', function() {
+  source.once('error', function(err) {
+    smart.emit('error', err);
     smart.end();
   })
   source.pipe(smart);
@@ -160,16 +161,19 @@ ZipArchiveOutputStream.prototype._smartStream = function(ae, callback) {
   var deflate = ae.getMethod() === constants.METHOD_DEFLATED;
   var process = deflate ? new DeflateCRC32Stream(this.options.zlib) : new CRC32Stream();
 
-  function handleStuff(err) {
+  var error = null
+  function handleStuff() {
     ae.setCrc(process.digest());
     ae.setSize(process.size());
     ae.setCompressedSize(process.size(true));
     this._afterAppend(ae);
-    callback(null, ae);
+    callback(error, ae);
   }
 
-  process.once('error', callback);
   process.once('end', handleStuff.bind(this));
+  process.once('error', function(err) {
+    error = err;
+  });
 
   process.pipe(this, { end: false });
 

--- a/lib/archivers/zip/zip-archive-output-stream.js
+++ b/lib/archivers/zip/zip-archive-output-stream.js
@@ -92,6 +92,9 @@ ZipArchiveOutputStream.prototype._appendStream = function(ae, source, callback) 
   this._writeLocalFileHeader(ae);
 
   var smart = this._smartStream(ae, callback);
+  source.once('error', function() {
+    smart.end();
+  })
   source.pipe(smart);
 };
 

--- a/test/zip-archive-output-stream.js
+++ b/test/zip-archive-output-stream.js
@@ -53,14 +53,24 @@ describe('ZipArchiveOutputStream', function() {
       var testStream = new WriteHashStream('tmp/zip-stream.zip');
       var entry = new ZipArchiveEntry('stream.txt');
 
+      var callbackError = null;
+      var callbackCalls = 0;
+
       testStream.on('close', function() {
+        assert.equal(callbackError.message, 'something went wrong');
+        assert.equal(callbackCalls, 1);
         done();
       });
 
       archive.pipe(testStream);
 
       var file = new stream.Transform();
-      archive.entry(entry, file, function() {}).finish();
+      archive.entry(entry, file, function(err) {
+        callbackCalls += 1;
+        callbackError = err;
+      });
+      archive.finish();
+
       process.nextTick(function() {
         file.emit('error', new Error('something went wrong'));
       })


### PR DESCRIPTION
If a stream is added as a zip file entry, an error event can leave the `DeflateCRC32Stream`/`CRC32Stream` that is created in `_smartStream()` open.

I don't think that's right. It makes more sense to me that the transform stream is closed on any errors in the source stream. Then it's much easier to recover from errors, and there's little chance that the zip stream will be open indefinitely.

I've refactored the code a little to propagate errors to the transform stream so that the error can be handled more gracefully. A test for it is also included.

Please let me know what you think.