### PR TITLE
Introduce 'forceZip64' option to ZipArchiveOutputStream

### DIFF
--- a/lib/archivers/zip/zip-archive-output-stream.js
+++ b/lib/archivers/zip/zip-archive-output-stream.js
@@ -25,6 +25,8 @@ var ZipArchiveOutputStream = module.exports = function(options) {
 
   options = this.options = this._defaults(options);
 
+  options.forceZip64 = !!options.forceZip64;
+
   ArchiveOutputStream.call(this, options);
 
   this._entry = null;
@@ -35,7 +37,8 @@ var ZipArchiveOutputStream = module.exports = function(options) {
     comment: '',
     finish: false,
     finished: false,
-    processing: false
+    processing: false,
+    forceZip64: options.forceZip64
   };
 };
 
@@ -419,7 +422,7 @@ ZipArchiveOutputStream.prototype.getComment = function(comment) {
 };
 
 ZipArchiveOutputStream.prototype.isZip64 = function() {
-  return this._entries.length > constants.ZIP64_MAGIC_SHORT || this._archive.centralLength > constants.ZIP64_MAGIC || this._archive.centralOffset > constants.ZIP64_MAGIC;
+  return this._archive.forceZip64 || this._entries.length > constants.ZIP64_MAGIC_SHORT || this._archive.centralLength > constants.ZIP64_MAGIC || this._archive.centralOffset > constants.ZIP64_MAGIC;
 };
 
 ZipArchiveOutputStream.prototype.setComment = function(comment) {


### PR DESCRIPTION
The flag, when set to true, forces creating the zip64 EOCD record and locator even if they're not needed for this file.

Mainly useful for testing - both the archiving code itself, and other libraries that need to consume zip64 files - as it makes it easier to generate zip64 files.