### PR TITLE
Improve ZIP compatibility

### DIFF
--- a/lib/archivers/zip/util.js
+++ b/lib/archivers/zip/util.js
@@ -49,7 +49,7 @@ util.getEightBytes = function(v) {
 
 util.getShortBytes = function(v) {
   var buf = new Buffer(2);
-  buf.writeUInt16LE(v, 0);
+  buf.writeUInt16LE((v & 0xFFFF) >>> 0, 0);
 
   return buf;
 };
@@ -60,7 +60,7 @@ util.getShortBytesValue = function(buf, offset) {
 
 util.getLongBytes = function(v) {
   var buf = new Buffer(4);
-  buf.writeUInt32LE(v, 0);
+  buf.writeUInt32LE((v & 0xFFFFFFFF) >>> 0, 0);
 
   return buf;
 };

--- a/lib/archivers/zip/zip-archive-entry.js
+++ b/lib/archivers/zip/zip-archive-entry.js
@@ -26,8 +26,8 @@ var ZipArchiveEntry = module.exports = function(name) {
   this.method = -1;
 
   this.name = null;
-  this.size = -1;
-  this.csize = -1;
+  this.size = 0;
+  this.csize = 0;
   this.gpb = new GeneralPurposeBit();
   this.crc = 0;
   this.time = -1;

--- a/lib/archivers/zip/zip-archive-output-stream.js
+++ b/lib/archivers/zip/zip-archive-output-stream.js
@@ -88,8 +88,10 @@ ZipArchiveOutputStream.prototype._appendBuffer = function(ae, source, callback) 
 };
 
 ZipArchiveOutputStream.prototype._appendStream = function(ae, source, callback) {
-  ae.getGeneralPurposeBit().useDataDescriptor(true);
-  ae.setVersionNeededToExtract(constants.MIN_VERSION_DATA_DESCRIPTOR);
+  if (ae.getMethod() === constants.METHOD_DEFLATED) {
+    ae.getGeneralPurposeBit().useDataDescriptor(true);
+    ae.setVersionNeededToExtract(constants.MIN_VERSION_DATA_DESCRIPTOR);
+  }
 
   this._writeLocalFileHeader(ae);
 

--- a/lib/archivers/zip/zip-archive-output-stream.js
+++ b/lib/archivers/zip/zip-archive-output-stream.js
@@ -88,7 +88,7 @@ ZipArchiveOutputStream.prototype._appendBuffer = function(ae, source, callback) 
 };
 
 ZipArchiveOutputStream.prototype._appendStream = function(ae, source, callback) {
-  if (ae.getMethod() === constants.METHOD_DEFLATED) {
+  if (ae.getMethod() !== constants.METHOD_STORED) {
     ae.getGeneralPurposeBit().useDataDescriptor(true);
     ae.setVersionNeededToExtract(constants.MIN_VERSION_DATA_DESCRIPTOR);
   }


### PR DESCRIPTION
- Some ZIP readers require the _data descriptor bit_ to not be set when `METHOD_STORED` is used (e.g: `java.util.zip.ZipInputStream`)
- Set mask on `writeUInt32LE` and `writeUInt16LE` to prevent `out of bounds` exception
- Set default size and compressed size to zero for improved compatibility

###### NOTE: this should fix compatibility for Java Archives