### PR TITLE
Fix ZIP64 directory header size

### DIFF
--- a/lib/archivers/zip/zip-archive-output-stream.js
+++ b/lib/archivers/zip/zip-archive-output-stream.js
@@ -224,7 +224,7 @@ ZipArchiveOutputStream.prototype._writeCentralDirectoryZip64 = function() {
   this.write(zipUtil.getLongBytes(constants.SIG_ZIP64_EOCD));
 
   // size of the ZIP64 EOCD record
-  this.write(zipUtil.getEightBytes(56));
+  this.write(zipUtil.getEightBytes(44));
 
   // version made by
   this.write(zipUtil.getShortBytes(constants.MIN_VERSION_ZIP64));


### PR DESCRIPTION
The spec says:

> should be the size of the remaining record and should not include the
> leading 12 bytes.