### PR TITLE
Add offset to buffer call

### DIFF
--- a/lib/archivers/zip/util.js
+++ b/lib/archivers/zip/util.js
@@ -36,7 +36,7 @@ util.dosToDate = function(dos) {
 };
 
 util.fromDosTime = function(buf) {
-  return util.dosToDate(buf.readUInt32LE());
+  return util.dosToDate(buf.readUInt32LE(0));
 };
 
 util.getEightBytes = function(v) {


### PR DESCRIPTION
In Node.js 10.x passing in the offset is mandatory. This makes sure everything continues to work as it should.

Please note: I could not find any places in the code that used `fromDosTime`. It might actually be a unused function and could be removed instead.

Refs: https://github.com/nodejs/node/pull/18395