### PR TITLE
Bump normalize-path to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "buffer-crc32": "^0.2.1",
     "crc32-stream": "^2.0.0",
-    "normalize-path": "^2.0.0",
+    "normalize-path": "^3.0.0",
     "readable-stream": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This will allow for better deduplication with `archiver-utils`