### PR TITLE
Including existing "extra" header when building central file header

### DIFF
--- a/lib/archivers/zip/zip-archive-output-stream.js
+++ b/lib/archivers/zip/zip-archive-output-stream.js
@@ -282,7 +282,7 @@ ZipArchiveOutputStream.prototype._writeCentralFileHeader = function(ae) {
       zipUtil.getEightBytes(offsets.file)
     ], 28);
 
-    ae.setExtra(extraBuf);
+    ae.setExtra(Buffer.concat([ae.getExtra(), extraBuf]));
   }
 
   // signature


### PR DESCRIPTION
This would allow including additional "extra" header information specified in extensions of archiver. Specifically, this fixes https://github.com/artem-karpenko/archiver-zip-encrypted/issues/30 to properly handle ZIP64 format in encrypted archives.