### PR TITLE
ZIP STORED method CRC32 and test

### DIFF
--- a/lib/archivers/zip/zip-archive-output-stream.js
+++ b/lib/archivers/zip/zip-archive-output-stream.js
@@ -6,7 +6,7 @@
  * https://github.com/archiverjs/node-compress-commons/blob/master/LICENSE-MIT
  */
 var inherits = require('util').inherits;
-var crc32 = require('buffer-crc32');
+var crc32 = require('crc-32').buf;
 var {CRC32Stream} = require('crc32-stream');
 var {DeflateCRC32Stream} = require('crc32-stream');
 
@@ -68,7 +68,7 @@ ZipArchiveOutputStream.prototype._appendBuffer = function(ae, source, callback) 
   if (method === constants.METHOD_STORED) {
     ae.setSize(source.length);
     ae.setCompressedSize(source.length);
-    ae.setCrc(crc32.unsigned(source));
+    ae.setCrc(crc32(source)>>>0);
   }
 
   this._writeLocalFileHeader(ae);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "mocha --reporter dot"
   },
   "dependencies": {
-    "buffer-crc32": "^0.2.13",
+    "crc-32": "^1.2.0",
     "crc32-stream": "^4.0.2",
     "normalize-path": "^3.0.0",
     "readable-stream": "^3.6.0"

--- a/test/zip-archive-output-stream.js
+++ b/test/zip-archive-output-stream.js
@@ -84,6 +84,7 @@ describe('ZipArchiveOutputStream', function() {
       var entry2 = new ZipArchiveEntry('buffer.txt');
       var entry3 = new ZipArchiveEntry('stream.txt');
       var entry4 = new ZipArchiveEntry('stream-store.png');
+      entry2.setMethod(0);
       entry4.setMethod(0);
 
       testStream.on('close', function() {


### PR DESCRIPTION
The zip output tests were missing a case of forcing a STORED file.

This is the only place using `buffer-crc32`.  Since the streaming `crc32-stream` library uses `crc-32`, the `archiver` tree pulls both.

For performance and historical reasons, it makes sense to de-dupe and use `crc-32`.  In [Node crc32](https://github.com/trivikr/benchmark-crc32) and in [Browser crc32](https://daninet.github.io/hash-wasm-benchmark/) benchmarks, `crc-32` is about twice as fast on very small data and an order of magnitude faster on larger data.