### PR TITLE
Set FileOffset field in central directory header to special value when including FileOffset in ZIP64 extra fields

### DIFF
--- a/lib/archivers/zip/zip-archive-output-stream.js
+++ b/lib/archivers/zip/zip-archive-output-stream.js
@@ -263,14 +263,15 @@ ZipArchiveOutputStream.prototype._writeCentralDirectoryZip64 = function() {
 ZipArchiveOutputStream.prototype._writeCentralFileHeader = function(ae) {
   var gpb = ae.getGeneralPurposeBit();
   var method = ae.getMethod();
-  var offsets = ae._offsets;
+  var fileOffset = ae._offsets.file;
 
   var size = ae.getSize();
   var compressedSize = ae.getCompressedSize();
 
-  if (ae.isZip64() || offsets.file > constants.ZIP64_MAGIC) {
+  if (ae.isZip64() || fileOffset > constants.ZIP64_MAGIC) {
     size = constants.ZIP64_MAGIC;
     compressedSize = constants.ZIP64_MAGIC;
+    fileOffset = constants.ZIP64_MAGIC;
 
     ae.setVersionNeededToExtract(constants.MIN_VERSION_ZIP64);
 
@@ -279,7 +280,7 @@ ZipArchiveOutputStream.prototype._writeCentralFileHeader = function(ae) {
       zipUtil.getShortBytes(24),
       zipUtil.getEightBytes(ae.getSize()),
       zipUtil.getEightBytes(ae.getCompressedSize()),
-      zipUtil.getEightBytes(offsets.file)
+      zipUtil.getEightBytes(ae._offsets.file)
     ], 28);
 
     ae.setExtra(extraBuf);
@@ -336,11 +337,7 @@ ZipArchiveOutputStream.prototype._writeCentralFileHeader = function(ae) {
   this.write(zipUtil.getLongBytes(ae.getExternalAttributes()));
 
   // relative offset of LFH
-  if (offsets.file > constants.ZIP64_MAGIC) {
-    this.write(zipUtil.getLongBytes(constants.ZIP64_MAGIC));
-  } else {
-    this.write(zipUtil.getLongBytes(offsets.file));
-  }
+  this.write(zipUtil.getLongBytes(fileOffset));
 
   // name
   this.write(name);


### PR DESCRIPTION
This fixes the root cause of [issue 371 in node-archiver](https://github.com/archiverjs/node-archiver/issues/371).  This should directly fix this issue when this PR is merged here, when [node-zip-stream](https://github.com/archiverjs/node-zip-stream) is updated to use this new version of node-compress-commons, and then when node-archiver is updated to use the new version of node-zip-stream.

Reason for the defect:
> The order of the fields in the ZIP64 extended information record is fixed, but the fields will only appear if the corresponding Local or Central directory record field is set to 0xFFFF or 0xFFFFFFFF.

Source: https://libzip.org/specifications/extrafld.txt

In the `ZipArchiveOutputStream._writeCentralFileHeader` method here, if the File Offset was smaller than the Zip64 limit (0xFFFFFFFF) but the Zip64 fields were needed for another large value (example: if the uncompressed file size is larger than 0xFFFFFFFF) then the File Offset was included in the Zip64 extra field but the normal 4-byte File Offset field in the central directory header, rather than the required value of 0xFFFFFFFF.

Validation:
* I reproduced the problem by using the [archiver v6.0.1](https://www.npmjs.com/package/archiver) module in NodeJs to stream about 5 GB of data to a single file within a zip archive with options `{ zlib: { level: 6 }, forceZip64: true }`.  Using 7Zip, I can unzip the file successfully but it gives the warning message "Warnings: Headers Error".  Opening the zip file in 7Zip and viewing the properties of the file within, it shows "Characteristics: Extra_ERROR Zip64_ERROR : Descriptor".
* I validated the fix by using a locally-patched version of the [archiver v6.0.1](https://www.npmjs.com/package/archiver) module with the same changes as in this PR, to stream the same ~5 GB data as above to a single file within a zip archive with options `{ zlib: { level: 6 }, forceZip64: true }`.  Using 7Zip, I can unzip the file successfully with no warning or error messages.  Opening the zip file in 7Zip and viewing the properties of the file within, it shows "Characteristics: Zip64 : Descriptor".

I have not added nor updated any unit tests, as I didn't find any tests that cover the modified areas of code or provide a framework to test these specific changes.